### PR TITLE
Add PUG extension template to wikisync

### DIFF
--- a/src/igem_wikisync/files.py
+++ b/src/igem_wikisync/files.py
@@ -129,6 +129,9 @@ class HTMLfile(BaseFile):
         return 'https://' + self._config['year'] + '.igem.org/wiki/index.php?title=Team:' + \
             self._config['team'] + self._upload_path + '&action=raw'
 
+class PUGfile(BaseFile):
+    # TODO: Insert PUGfile class here
+    pass
 
 class CSSfile(BaseFile):
     def __init__(self, path, config):

--- a/src/igem_wikisync/parsers.py
+++ b/src/igem_wikisync/parsers.py
@@ -61,6 +61,11 @@ def HTMLparser(config: dict, path, contents: str, upload_map: dict) -> str:
     return contents
 
 
+def PUGparser():
+    # TODO: Insert PUG parser here
+    pass
+
+
 def CSSparser(config: dict, path, contents: str, upload_map: dict) -> str:
     """
     Parses a given CSS string and

--- a/src/igem_wikisync/path.py
+++ b/src/igem_wikisync/path.py
@@ -2,7 +2,7 @@ import os
 import re
 from pathlib import Path
 
-from igem_wikisync.files import CSSfile, HTMLfile, JSfile
+from igem_wikisync.files import CSSfile, HTMLfile, JSfile, PUGfile
 from igem_wikisync.logger import logger
 
 
@@ -53,7 +53,7 @@ def resolve_relative_path(path: str, parent: Path, src_dir: str) -> Path:
         full_path = (src_dir / parent / path).resolve()
 
     if full_path.is_dir() or full_path.suffix == '':
-        return (full_path / 'index.html').relative_to(src_dir)
+        return (full_path / 'index.html').relative_to(src_dir) # TODO: return index.pug somehow?
     else:
         return full_path.relative_to(src_dir)
 
@@ -120,6 +120,9 @@ def iGEM_URL(config: dict, path: Path, upload_map: dict, url: str) -> str:
             url = file_object.link_URL
         elif extension == 'js':
             file_object = JSfile(resolved_path, config)
+            url = file_object.link_URL
+        elif extension == 'pug':
+            file_object = PUGfile(resolved_path, config)
             url = file_object.link_URL
         # leave unchanged
         else:


### PR DESCRIPTION
The iGEM Wiki Starter Pack pages are Pug instead of HTML files, but the .pug file extension is not included in the wikisync script (so none of the pages are actually uploaded to the iGEM servers). Pull will add template for .pug extension, but it's still missing file class and parser functionality (I wasn't sure how to implement it so you'll probably have to do it instead).  Presumably missing functionality is marked with TODO messages.