### PR TITLE
Relative path looking for a common root resolved

### DIFF
--- a/.venv/pyvenv.cfg
+++ b/.venv/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /opt/python/3.8.6/bin
+include-system-site-packages = false
+version = 3.8.6

--- a/.venv/pyvenv.cfg
+++ b/.venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /opt/python/3.8.6/bin
-include-system-site-packages = false
-version = 3.8.6

--- a/src/igem_wikisync/path.py
+++ b/src/igem_wikisync/path.py
@@ -55,7 +55,7 @@ def resolve_relative_path(path: str, parent: Path, src_dir: str) -> Path:
     if full_path.is_dir() or full_path.suffix == '':
         return (full_path / 'index.html').relative_to(src_dir)
     else:
-        return full_path.relative_to(src_dir)
+        return Path(os.path.relpath(full_path, src_dir))
 
 
 def iGEM_URL(config: dict, path: Path, upload_map: dict, url: str) -> str:


### PR DESCRIPTION
A value error was raised when looking files with common root, for example when index.html was in src folder it was raising an error when running wikisync.py. I looked into some posts and found the following solution helpful.

Source:
https://stackoverflow.com/questions/38083555/using-pathlibs-relative-to-for-directories-on-the-same-level

I also want to thank igembitsgoa team for providing such an amazing tool!